### PR TITLE
Readme : fix link to contributors page - issue #66

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The majority of this manual was created by Andre Bernet.
 
-Other contributors listed here: [Contributors](contributors.md)  
+Other contributors listed here: [Contributors](https://raw.githubusercontent.com/opentx/opentx/2.2/CREDITS.txt)
 
 Commercial use forbidden without explicit authorization of the authors and translators. 
 


### PR DESCRIPTION
Replace outdated contributions.md and link to CREDITS.TXT (we should add the doc only authors to CREDITS.txt (Mike Barsalou))